### PR TITLE
Added doxygen patterns, modified settings names, corrected the incorrect load of settings files

### DIFF
--- a/DoxyDoc.sublime-settings
+++ b/DoxyDoc.sublime-settings
@@ -1,11 +1,11 @@
 {
-    "enabled": true,
+    "doxydoc_enabled": true,
 
     // if set to true, the commands will be prefixed with @
     // otherwise they will be prefixed with \
-    "javadoc": false,
+    "doxydoc_javadoc": false,
 
     // the maximum amount of lines to parse to retrieve
     // all the parameters of a function or class
-    "max_lines": 5
+    "doxydoc_max_lines": 5
 }


### PR DESCRIPTION
I added new patterns for doxygen : class, struct, enum, define, start of file (symbolized by include).
When one of these patterns is detected, the special comment block created is changed to be more accurate, and use specific doxygen commands.

I also modified the name for the load_settings function, as it was not the right setting file name ("DoxyDoc.sublime-settings" instead of "Doxydoc.sublime-settings", so the setting file was never loaded, and the javadoc setting was always at true).

I changed the name of the settings, because if other packages use those same names, there will be conflicts, so better safe than sorry.

Added few regexp for identifiers, though they may be clunky (i'm not an expert of regexp), they work for the things i do, and don't break anything.